### PR TITLE
Update 2022-08-23.tex

### DIFF
--- a/lec/notes/2022-08-23.tex
+++ b/lec/notes/2022-08-23.tex
@@ -509,7 +509,7 @@ class, we will see several interpretations of matrices:
   if $v = Vc$ and $w = Wd$ then $a(v,w) = d^* A c$.
 
   We call a sesquilinear form on $\calV \times \calV$ {\em Hermitian} if
-  $a(v,w) = \bar{a(w,v)}$; in this case, the corresponding matrix $A$ is
+  $a(v,w) = \overline{a(w,v)}$; in this case, the corresponding matrix $A$ is
   also Hermitian ($A = A^*$).  A Hermitian form and the corresponding
   matrix are called {\em positive semi-definite} if $a(v,v) \geq 0$
   for all $v$.  The form and matrix are {\em positive definite} if
@@ -517,7 +517,7 @@ class, we will see several interpretations of matrices:
 
   A {\em skew-Hermitian} matrix
   ($A = -A^*$) corresponds to a skew-Hermitian or anti-Hermitian bilinear
-  form, i.e.~$a(v,w) = -a(w,v)$.
+  form, i.e.~$a(v,w) = -\overline{a(w,v)}$.
 \item {\bf Quadratic forms}.  A quadratic form $\phi : \calV
   \rightarrow \bbR$ (or $\bbC$) is a homogeneous quadratic function
   on $\calV$, i.e.~$\phi(\alpha v) = \alpha^2 \phi(v)$ for which the


### PR DESCRIPTION
Line 512: Replaced \bar with \overline (\bar renders too small).
Line 520: Added \overline in definition of anti-Hermitian bilinear form.